### PR TITLE
feat: add collect agg function

### DIFF
--- a/crates/elio-logictest/tests/func/agg.slt
+++ b/crates/elio-logictest/tests/func/agg.slt
@@ -31,3 +31,38 @@ UNWIND [1, 1, 2, 2, 2] AS x RETURN x, count(*)
 1	2
 2	3
 
+# collect basic
+query A
+UNWIND [1, 2, 3] AS x RETURN collect(x)
+----
+[1, 2, 3]
+
+# collect with nulls should skip nulls
+query A
+UNWIND [1, null, 3, null, 5] AS x RETURN collect(x)
+----
+[1, 3, 5]
+
+# collect strings
+query A
+UNWIND ['a', 'b', 'c'] AS x RETURN collect(x)
+----
+['a', 'b', 'c']
+
+# collect with GROUP BY
+query AA
+UNWIND [1, 1, 2, 2, 2] AS x RETURN x, collect(x)
+----
+1	[1, 1]
+2	[2, 2, 2]
+
+# collect empty result (all nulls)
+query A
+UNWIND [null, null] AS x RETURN collect(x)
+----
+[]
+
+# collect with DISTINCT (not supported yet)
+statement error
+UNWIND [1, 2, 1, 3, 2, 3] AS x RETURN collect(DISTINCT x)
+

--- a/crates/elio-query/src/function/agg/collect.rs
+++ b/crates/elio-query/src/function/agg/collect.rs
@@ -1,0 +1,73 @@
+//! Collect aggregate function
+//! variants:
+//!  - collect(expr): collects non-null values into a list
+//!
+//! outputs:
+//!  - List
+//!
+//! null handling:
+//!  - ignores nulls
+
+use std::sync::Arc;
+
+use elio_common::data_type::LogicalType;
+use elio_common::scalar::list::ListValue;
+use elio_common::scalar::{Datum, DatumRef, ScalarValue};
+
+use crate::agg_function;
+use crate::execution::error::EvalError;
+use crate::execution::expr::AggFunctionExec;
+use crate::execution::expr::agg_call::AggFunctionState;
+use crate::function::AggFunctionRegistry;
+use crate::function::sig::AggFunctionSet;
+
+struct CollectState {
+    values: Vec<ScalarValue>,
+}
+
+impl CollectState {
+    fn new() -> Self {
+        Self { values: Vec::new() }
+    }
+}
+
+impl AggFunctionState for CollectState {}
+
+#[derive(Debug)]
+struct CollectFunctionExec;
+
+impl AggFunctionExec for CollectFunctionExec {
+    fn create_state(&self) -> Box<dyn AggFunctionState> {
+        Box::new(CollectState::new())
+    }
+
+    fn update_state(&self, state: &mut Box<dyn AggFunctionState>, row: &[DatumRef]) -> Result<(), EvalError> {
+        assert_eq!(row.len(), 1);
+        // skip nulls
+        match row[0] {
+            None | Some(ScalarValue::Unknown) => return Ok(()),
+            _ => {}
+        }
+        let state = state
+            .downcast_mut::<CollectState>()
+            .ok_or_else(|| EvalError::type_error("collect state type mismatch"))?;
+        state.values.push(row[0].unwrap().clone());
+        Ok(())
+    }
+
+    fn extract_value(&self, state: &mut Box<dyn AggFunctionState>) -> Datum {
+        let state = state.downcast_mut::<CollectState>().expect("expected collect state");
+        let values = std::mem::take(&mut state.values);
+        Some(ScalarValue::List(Box::new(ListValue::new(values))))
+    }
+}
+
+pub(crate) fn register(registry: &mut AggFunctionRegistry) {
+    let mut collect = AggFunctionSet::new("collect");
+    collect.add_function(agg_function!(
+        "collect",
+        [LogicalType::ANY] -> LogicalType::new_list(LogicalType::ANY),
+        |_args| Ok(Arc::new(CollectFunctionExec))
+    ));
+    registry.insert(collect);
+}

--- a/crates/elio-query/src/function/agg/mod.rs
+++ b/crates/elio-query/src/function/agg/mod.rs
@@ -1,9 +1,11 @@
 use crate::function::AggFunctionRegistry;
 
+pub mod collect;
 pub mod count;
 pub mod sum;
 
 pub(crate) fn register(registry: &mut AggFunctionRegistry) {
+    collect::register(registry);
     count::register(registry);
     sum::register(registry);
 }


### PR DESCRIPTION
## Summary
- Add `collect(expr)` aggregate function that collects non-null values into a list
- Null values are skipped during collection
- Works with GROUP BY to collect values per group

## Test plan
- [x] Logic tests: basic collect, null handling, strings, GROUP BY, empty result, DISTINCT error
- [x] Planner tests pass
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)